### PR TITLE
fix missing move_base_msgs depend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ if(BUILD_OPENVINO STREQUAL "ON")
      behaviortree_cpp_v3
      roscpp
      std_msgs
+     move_base_msgs
      object_msgs
    )
    add_definitions(-DSUPPORT_OPENVINO)
@@ -25,6 +26,7 @@ else()
      behaviortree_cpp_v3
      roscpp
      std_msgs
+     move_base_msgs
    )
 endif()
 

--- a/package.xml
+++ b/package.xml
@@ -54,16 +54,19 @@
   <build_depend>behaviortree_cpp_v3</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>move_base_msgs</build_depend>
   <build_export_depend>actionlib</build_export_depend>
   <build_export_depend>actionlib_msgs</build_export_depend>
   <build_export_depend>behaviortree_cpp_v3</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>move_base_msgs</build_export_depend>
   <exec_depend>actionlib</exec_depend>
   <exec_depend>actionlib_msgs</exec_depend>
   <exec_depend>behaviortree_cpp_v3</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>move_base_msgs</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
fix missing move_base_msgs depend in CMakeLists.txt and package.xml