### PR TITLE
Add ZMQ server

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -52,18 +52,21 @@
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>behaviortree_cpp_v3</build_depend>
+  <build_depend>libzmq3-dev</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>move_base_msgs</build_depend>
   <build_export_depend>actionlib</build_export_depend>
   <build_export_depend>actionlib_msgs</build_export_depend>
   <build_export_depend>behaviortree_cpp_v3</build_export_depend>
+  <build_export_depend>libzmq3-dev</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>move_base_msgs</build_export_depend>
   <exec_depend>actionlib</exec_depend>
   <exec_depend>actionlib_msgs</exec_depend>
   <exec_depend>behaviortree_cpp_v3</exec_depend>
+  <exec_depend>libzmq3-dev</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>move_base_msgs</exec_depend>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #endif
 #include <behaviortree_cpp_v3/bt_factory.h>
 #include <behaviortree_cpp_v3/loggers/bt_cout_logger.h>
+#include <behaviortree_cpp_v3/loggers/bt_zmq_publisher.h>
 
 using namespace BT;
 
@@ -36,6 +37,9 @@ int main(int argc, char **argv) {
   // the beginning). The currently supported format is XML. IMPORTANT: when the
   // object "tree" goes out of scope, all the TreeNodes are destroyed
   auto tree = factory.createTreeFromFile(xml_filename);
+
+  // ZMQ server for Groot
+  auto publisher_zmq = std::make_shared<BT::PublisherZMQ>(tree, 10, 1666, 1667);
 
   // Create a logger
   StdCoutLogger logger_cout(tree);


### PR DESCRIPTION
Add ZMQ server that can track behavior tree node status in Groot monitor by connecting to ports 1666 and 1667.